### PR TITLE
A few minor improvements to the launch script for portability

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -9,7 +9,7 @@ if [ -z "$visual_id" ]; then
 fi
 
 if [ -z "$visual_id" ]; then
-    visual_id=$(xdpyinfo 2>/dev/null | grep "visual id" | grep -B 5 "depth:      32 planes" | grep "visual id" | awk '{print $3}' | head -n1)
+    visual_id=$(glxinfo -v 2>/dev/null | grep "Visual ID" | grep "depth=32" | awk '{print $3}' | head -n1)
 fi
 
 echo "Visual ARGB: $visual_id"


### PR DESCRIPTION
Add a few small changes to make the launch script more portable.

I also had some changes to make the visual ID selection more accurate, but commit 8f7caa1b5536b467ecc6a59f17bd776ccd11a6e5 fixed the problems I was having. Still, I think it should be sufficient to check for depth=32 when looking for a suitable visual - I can't imagine 32-bit colours not having an alpha channel. In other words, all but the last check can probably be removed. I haven't done that in this PR in case it breaks on someone else's system despite working on mine.